### PR TITLE
fixed gemname in Guardfile template

### DIFF
--- a/lib/guard/rackunit/templates/Guardfile
+++ b/lib/guard/rackunit/templates/Guardfile
@@ -1,4 +1,4 @@
 # This Guardfile was generated from Guard::RackUnit
-guard :rack_unit, all_on_start: true, test_paths: ["tests/"] do
+guard :rackunit, all_on_start: true, test_paths: ["tests/"] do
   watch(%r{^tests/.+-tests.rkt$})
 end


### PR DESCRIPTION
The Guardfile that is currently being generated on init throws an error when used:

```
bundle exec guard
18:57:44 - ERROR - Could not load 'guard/rack_unit' or find class Guard::RackUnit
18:57:44 - ERROR - /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/plugin_util.rb:100:in `require'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/plugin_util.rb:100:in `plugin_class'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/plugin_util.rb:57:in `initialize_plugin'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard.rb:167:in `add_plugin'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/dsl.rb:176:in `block in guard'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/dsl.rb:174:in `each'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/dsl.rb:174:in `guard'
> [#] /home/hobofan/stuff/racket-csg/Guardfile:5:in `_instance_eval_guardfile'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/guardfile/evaluator.rb:121:in `instance_eval'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/guardfile/evaluator.rb:121:in `_instance_eval_guardfile'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/guardfile/evaluator.rb:37:in `evaluate_guardfile'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/setuper.rb:146:in `evaluate_guardfile'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/setuper.rb:64:in `setup'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/commander.rb:24:in `start'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/cli.rb:107:in `start'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
> [#] /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/bin/guard:6:in `<top (required)>'
> [#] /home/hobofan/.rbenv/versions/2.2.0/bin/guard:23:in `load'
> [#] /home/hobofan/.rbenv/versions/2.2.0/bin/guard:23:in `<main>'
18:57:44 - ERROR - Invalid Guardfile, original error is:
> [#] undefined method `superclass' for nil:NilClass
/home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/plugin_util.rb:57:in `initialize_plugin': undefined method `superclass' for nil:NilClass (NoMethodError)
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard.rb:167:in `add_plugin'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/dsl.rb:176:in `block in guard'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/dsl.rb:174:in `each'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/dsl.rb:174:in `guard'
    from /home/hobofan/stuff/racket-csg/Guardfile:5:in `_instance_eval_guardfile'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/guardfile/evaluator.rb:121:in `instance_eval'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/guardfile/evaluator.rb:121:in `_instance_eval_guardfile'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/guardfile/evaluator.rb:37:in `evaluate_guardfile'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/setuper.rb:146:in `evaluate_guardfile'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/setuper.rb:64:in `setup'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/commander.rb:24:in `start'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/lib/guard/cli.rb:107:in `start'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /home/hobofan/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/guard-2.5.1/bin/guard:6:in `<top (required)>'
    from /home/hobofan/.rbenv/versions/2.2.0/bin/guard:23:in `load'
    from /home/hobofan/.rbenv/versions/2.2.0/bin/guard:23:in `<main>'
```

This is fixed by changing the guard name to the name that is used everywhere else.
